### PR TITLE
Google OAuth2 Scope changed to add openid

### DIFF
--- a/flask_oauth2_login/google.py
+++ b/flask_oauth2_login/google.py
@@ -9,6 +9,7 @@ class GoogleLogin(OAuth2Login):
 
   default_scope = (
     "https://www.googleapis.com/auth/userinfo.email,"
+    "openid,"
     "https://www.googleapis.com/auth/userinfo.profile"
   )
   default_redirect_path = "/login/google"


### PR DESCRIPTION
Simple fix, but Google Login doesn't work without this.